### PR TITLE
Push rider token to front when mounting.

### DIFF
--- a/src/module/mounting.ts
+++ b/src/module/mounting.ts
@@ -45,6 +45,17 @@ export class Mounting {
       y: riderToken.document.y,
     });
 
+    // Push token to front of token "stack"
+    // This makes some fairly heavy assumptions. There has to be a better practice here...
+    
+    // Code shamlessly borrowed from: https://github.com/David-Zvekic/pushTokenBack/blob/main/pushTokenBack.js#L61
+    // @ts-ignore
+    const riderIndex = getCanvas().tokens?.children[0].children.findIndex((t) => t.id == mountToken.id);
+    // @ts-ignore
+    canvas?.tokens.children[0].children.splice(riderIndex, 1);
+    // @ts-ignore
+    canvas?.tokens.children[0].children.unshift(mountToken);
+
     // @ts-ignore
     await window['tokenAttacher'].attachElementToToken(mountToken, riderToken, true);
 

--- a/src/module/mounting.ts
+++ b/src/module/mounting.ts
@@ -50,9 +50,9 @@ export class Mounting {
 
     // Code shamlessly borrowed from: https://github.com/David-Zvekic/pushTokenBack/blob/main/pushTokenBack.js#L61
     // @ts-ignore
-    const riderIndex = getCanvas().tokens?.children[0].children.findIndex((t) => t.id == mountToken.id);
+    const mountIndex = getCanvas().tokens?.children[0].children.findIndex((t) => t.id == mountToken.id);
     // @ts-ignore
-    canvas?.tokens.children[0].children.splice(riderIndex, 1);
+    canvas?.tokens.children[0].children.splice(mountIndex, 1);
     // @ts-ignore
     canvas?.tokens.children[0].children.unshift(mountToken);
 

--- a/src/module/mounting.ts
+++ b/src/module/mounting.ts
@@ -47,7 +47,7 @@ export class Mounting {
 
     // Push token to front of token "stack"
     // This makes some fairly heavy assumptions. There has to be a better practice here...
-    
+
     // Code shamlessly borrowed from: https://github.com/David-Zvekic/pushTokenBack/blob/main/pushTokenBack.js#L61
     // @ts-ignore
     const riderIndex = getCanvas().tokens?.children[0].children.findIndex((t) => t.id == mountToken.id);


### PR DESCRIPTION
Rider token is pushed to the front of the token "stack" when it mounts, in order to ensure that it's clickable.